### PR TITLE
WIP: Add simple docstring help system based for FemtoLisp.

### DIFF
--- a/lib/femto-docs.scm
+++ b/lib/femto-docs.scm
@@ -1,0 +1,87 @@
+;;;; FemtoLisp Documentation System
+
+
+(define (docstring f)
+    "
+        (docstring f)
+
+    Retrieve and display function `f` docstring.
+
+    # Usage
+
+    ```
+    > (docstring help)
+    \"\n        (help f)\n\n    Displays documentation for function `f`.\n\n    # Usage\n\n    ```\n    > (help docstring)\n\n           (docstring f)\n        Retrieve and display function `f` docstring.\n\n    #t\n\n    > (help princ)\n\n        No documentation found for `princ`.\n\n    #t\n\n    > (help 'foo)\n    type error: function:name: expected function, got foo\n    #0 (help foo)\n    ```\n    \"
+
+    > (docstring princ)
+    \"\"
+
+    > (docstring 'foo)
+    type error: function:vals: expected function, got foo
+    #0 (docstring foo)
+    ```
+    "
+    (let* ((function-values (function:vals f))
+           (first-value     (aref function-values 0))
+           (doc-string      (if (string? first-value)
+                                first-value
+                                "")))
+
+          doc-string))
+
+
+(define (help f)
+    "
+        (help f)
+
+    Displays documentation for function `f`.
+
+    # Usage
+
+    ```
+    > (help docstring)
+
+            (docstring f)
+
+        Retrieve and display function `f` docstring.
+
+        # Usage
+
+        ```
+        > (docstring help)
+        "
+            (help f)
+
+        Displays documentation for function `f`.
+        "
+
+        > (docstring princ)
+        ""
+
+        > (docstring 'foo)
+        type error: function:vals: expected function, got foo
+        #0 (docstring foo)
+        ```
+
+    #t
+
+    > (help princ)
+
+        No documentation found for `princ`.
+
+    #t
+
+    > (help 'foo)
+    type error: function:name: expected function, got foo
+    #0 (help foo)
+    ```
+    "
+    (let* ((function-name     (function:name f))
+           (doc-string        (docstring f))
+           (docstring-message (if (eq? doc-string "")
+               (string "\n    No documentation found for `"
+                              function-name
+                              "`.\n\n")
+               (string doc-string "\n"))))
+
+          (with-output-to *output-stream* (princ docstring-message))))


### PR DESCRIPTION
This PR implements a symple documentation system for use in flsip:

```lisp
ismaelvc@toybox:~$ rlwrap julia --lisp
;  _
; |_ _ _ |_ _ |  . _ _
; | (-||||_(_)|__|_)|_)
;-------------------|----------------------------------------------------------

> (load "femto-docs.scm")
#fn("=000r1c02c1|31e2|31g6c3\x82?0c4c5g5c6335:0c4g6c732e8e8k82c9g8q1c:g7q1c;g9q1tg9302;" ["\n        (help f)\n\n    Displays documentation for function `f`.\n\n    # Usage\n\n    ```\n    > (help docstring)\n\n            (docstring f)\n\n        Retrieve and display function `f` docstring.\n\n        # Usage\n\n        ```\n        > (docstring help)\n        \"\n            (help f)\n\n        Displays documentation for function `f`.\n        \"\n\n        > (docstring princ)\n        \"\"\n\n        > (docstring 'foo)\n        type error: function:vals: expected function, got foo\n        #0 (docstring foo)\n        ```\n\n    #t\n\n    > (help princ)\n\n        No documentation found for `princ`.\n\n    #t\n\n    > (help 'foo)\n    type error: function:name: expected function, got foo\n    #0 (help foo)\n    ```\n    "
  #fn(function:name) docstring "" #fn(string)
  "\n    No documentation found for `" "`.\n\n" "\n" *output-stream* #fn("5000r0~k0;" [*output-stream*])
  #fn("6000r0e0~41;" [princ]) #fn("6000r1~302c0|41;" [#fn(raise)])] help)

> (docstring help)
"\n        (help f)\n\n    Displays documentation for function `f`.\n\n    # Usage\n\n    ```\n    > (help docstring)\n\n            (docstring f)\n\n        Retrieve and display function `f` docstring.\n\n        # Usage\n\n        ```\n        > (docstring help)\n        \"\n            (help f)\n\n        Displays documentation for function `f`.\n        \"\n\n        > (docstring princ)\n        \"\"\n\n        > (docstring 'foo)\n        type error: function:vals: expected function, got foo\n        #0 (docstring foo)\n        ```\n\n    #t\n\n    > (help princ)\n\n        No documentation found for `princ`.\n\n    #t\n\n    > (help 'foo)\n    type error: function:name: expected function, got foo\n    #0 (help foo)\n    ```\n    "

> (docstring princ)
""

> (docstring 'foo)
type error: function:vals: expected function, got foo
#0 (docstring foo)

> (help docstring)

        (docstring f)

    Retrieve and display function `f` docstring.

    # Usage

    ```
    > (docstring help)
    "
        (help f)

    Displays documentation for function `f`.

    # Usage

    ```
    > (help docstring)

           (docstring f)
        Retrieve and display function `f` docstring.

    #t

    > (help princ)

        No documentation found for `princ`.

    #t

    > (help 'foo)
    type error: function:name: expected function, got foo
    #0 (help foo)
    ```
    "

    > (docstring princ)
    ""

    > (docstring 'foo)
    type error: function:vals: expected function, got foo
    #0 (docstring foo)
    ```
    
#t

> (help princ)

    No documentation found for `princ`.

#t

> (help 'foo)
type error: function:name: expected function, got foo
#0 (help foo)

> 
ismaelvc@toybox:~$ julia -v
julia version 0.6.0-dev
```
```